### PR TITLE
fix: exclude 'condition' from task interpretation in getTasks method

### DIFF
--- a/src/lemniscat/runtime/model/models.py
+++ b/src/lemniscat/runtime/model/models.py
@@ -92,7 +92,7 @@ class Template:
     
     def getTasks(self) -> List[Task]:
         tasks = FileSystem.load_configuration_path(self.path)
-        Interpreter(LogUtil.root, self._variables).interpretDict(tasks)
+        Interpreter(LogUtil.root, self._variables).interpretDict(tasks, excludeInterpret=['condition'])
         result = []
         for task in tasks['tasks']:
             task['prefix'] = self.displayName


### PR DESCRIPTION
This pull request includes a change to the `src/lemniscat/runtime/model/models.py` file to modify the behavior of the `Interpreter` class when interpreting task dictionaries.

Changes to task interpretation:

* [`src/lemniscat/runtime/model/models.py`](diffhunk://#diff-65a281ed32f0c65ba547af593dc2aee3a95889c29e6a422672815623b006be35L95-R95): Updated the `interpretDict` method call to exclude the interpretation of 'condition' by adding an `excludeInterpret` parameter with the value `['condition']`.