### PR TITLE
fix: exclude capability variable form output context

### DIFF
--- a/src/lemniscat/runtime/engine/engine_runtime.py
+++ b/src/lemniscat/runtime/engine/engine_runtime.py
@@ -164,6 +164,7 @@ class OrchestratorEngine:
   
         if(self._outputContextPath is not None):
             self._logger.info(f"Saving output context...")
+            self._bagOfVariables.remove("capability")
             self._bagOfVariables.save(self._outputContextPath)
             self._logger.info(f"Output context saved to: {self._outputContextPath}")
         return status

--- a/src/lemniscat/runtime/engine/engine_variables.py
+++ b/src/lemniscat/runtime/engine/engine_variables.py
@@ -131,6 +131,12 @@ class BagOfVariables:
     def append(self, variables: dict) -> None:
         self._variables.update(variables)
         
+    def remove(self, key: str) -> None:
+        if key in self._variables:
+            del self._variables[key]
+        else:
+            self._logger.error(f"Variable '{key}' not found")
+        
     def save(self, filePath: str) -> None:
         output = {}
         for key in self._variables:

--- a/src/lemniscat/runtime/model/models.py
+++ b/src/lemniscat/runtime/model/models.py
@@ -99,6 +99,11 @@ class Template:
         result = []
         for task in tasks['tasks']:
             task['prefix'] = self.displayName
+            if(self.condition is not None and task.__contains__('condition')):
+                task['condition'] = "(" + self.condition + ") & (" + task['condition'] + ")"
+            elif(self.condition is not None):
+                task['condition'] = self.condition
+                
             if(dict(task).keys().__contains__('template')):
                 result.extend(Template(self._variables, **task).getTasks())
             else:

--- a/src/lemniscat/runtime/model/models.py
+++ b/src/lemniscat/runtime/model/models.py
@@ -99,11 +99,6 @@ class Template:
         result = []
         for task in tasks['tasks']:
             task['prefix'] = self.displayName
-            if(self.condition is not None and task.__contains__('condition')):
-                task['condition'] = "(" + self.condition + ") & (" + task['condition'] + ")"
-            elif(self.condition is not None):
-                task['condition'] = self.condition
-                
             if(dict(task).keys().__contains__('template')):
                 result.extend(Template(self._variables, **task).getTasks())
             else:


### PR DESCRIPTION
This pull request introduces a new method to remove variables from the `_bagOfVariables` and integrates its use into the `engine_runtime` module. The most important changes include adding the `remove` method in `engine_variables.py` and updating `engine_runtime.py` to utilize this new functionality.

### Changes to variable management:

* [`src/lemniscat/runtime/engine/engine_variables.py`](diffhunk://#diff-4afd1dbcd1053a6d68740ea31d992cd698da46e5907e55a5363d8a44a5fda949R134-R139): Added a `remove` method to the `_bagOfVariables` class, allowing for the deletion of a variable by key. If the key does not exist, an error is logged.

* [`src/lemniscat/runtime/engine/engine_runtime.py`](diffhunk://#diff-8a7e1856a00749cf16a0913037e9dd49fa864b5a39f90421f23ca06cea6bebe9R167): Updated the `start` method to call the new `remove` method on `_bagOfVariables` to delete the "capability" variable before saving the output context.